### PR TITLE
Add a download columns for linux and associated instructions

### DIFF
--- a/website/docs/HowTo/how_to_export_flowsheet.mdx
+++ b/website/docs/HowTo/how_to_export_flowsheet.mdx
@@ -1,5 +1,5 @@
 ---
-title: How to export flowsheet to UI
+title: How to export flowsheets to the UI
 sidebar_position: 3
 ---
 

--- a/website/docs/HowTo/how_to_use_ui.mdx
+++ b/website/docs/HowTo/how_to_use_ui.mdx
@@ -1,5 +1,5 @@
 ---
-title: How to use UI
+title: How to use the UI
 sidebar_position: 1
 ---
 

--- a/website/docs/HowTo/install_linux_deb.mdx
+++ b/website/docs/HowTo/install_linux_deb.mdx
@@ -1,0 +1,28 @@
+---
+title: How to install Linux packages
+sidebar_position: 4
+---
+
+# How to install Linux Debian packages
+
+For some releases Linux `.deb` (Debian) packages are available.
+These can be installed on a Linux [Debian-based distribution](https://en.wikipedia.org/wiki/Category:Debian-based_distributions)
+(including Ubuntu Linux),
+You will use `sudo` to accquire administrative (root) permissions on your machine.
+
+After clicking on and downloading the installer file (ending in `.deb`), follow these steps:
+
+1. Open a new terminal
+2. Change to the directory with the downloaded file:
+```
+cd Downloads
+```
+3. Use `dpkg` to install the file. The 'sudo' command should require your password:
+```
+sudo dpkg -i "WaterTAP-Flowsheet-Processor_*.deb"
+``` 
+4. Run the installed package
+```
+watertap-flowsheet-processor-ui
+``` 
+

--- a/website/src/components/InstallerTable/InstallerTable.js
+++ b/website/src/components/InstallerTable/InstallerTable.js
@@ -141,7 +141,9 @@ function InstallerTable({owner, repo}) {
     for (let release of data) {
         if (release.assets?.length > 0) {
             for (let asset of release.assets) {
-                if (asset.name.toLowerCase().includes(project) && (asset.name.endsWith(".exe") || asset.name.endsWith(".dmg"))) {
+                if (asset.name.toLowerCase().includes(project) && (asset.name.endsWith(".exe") || asset.name.endsWith(".dmg")
+                || asset.name.endsWith(".deb") // NEW
+              )) {
                     releasesWithInstaller.push(release)
                     break
                 }
@@ -184,6 +186,8 @@ function InstallerTable({owner, repo}) {
 
       const windowsLink = release.assets.find(asset => asset.name.toLowerCase().includes(project) && asset.name.endsWith(".exe"));
       const macLink = release.assets.find(asset => asset.name.toLowerCase().includes(project) && asset.name.endsWith(".dmg"));
+      // NEW
+      const linuxLink = release.assets.find(asset => asset.name.toLowerCase().includes(project) && asset.name.endsWith(".deb"));
 
       let UI_version = parseUIVersionNumber(windowsLink?.name || "");
       if (!UI_version) UI_version = parseUIVersionNumber(macLink?.name || "");
@@ -213,6 +217,15 @@ function InstallerTable({owner, repo}) {
               '-'
             )}
           </td>
+          <td style={index === 0 ? { ...styles.td, ...styles.stableReleaseTd } : styles.td}>
+            {linuxLink ? (
+              <a href={linuxLink.browser_download_url} target="_blank" rel="noreferrer" style={styles.link}>
+                <button style={styles.button}>Download</button>
+              </a>
+            ) : (
+              '-'
+            )}
+          </td>
         </tr>
       );
     });
@@ -232,6 +245,7 @@ function InstallerTable({owner, repo}) {
               <th style={styles.th}>{project_name} Version</th>
               <th style={styles.th}>Windows (.exe)</th>
               <th style={styles.th}>macOS (.dmg)</th>
+              <th style={styles.th}>Linux (.deb) <a href="/idaes-flowsheet-processor-ui/docs/HowTo/install_linux_deb">?</a></th>
             </tr>
           </thead>
           <tbody>


### PR DESCRIPTION
Currently we have Debian packages but we're not showing them on the download site.
They are not one-click installers, so additional instructions are needed.
This PR adds the column and populates it as much as possible.
A new docs page describes how to install the package.
A relatively small link (on a `?`) is added in the Linux column header linking to the docs page, so the instructions can be found.